### PR TITLE
Fix not loading separators

### DIFF
--- a/WtHud2/ConfigForm.cs
+++ b/WtHud2/ConfigForm.cs
@@ -258,7 +258,11 @@ namespace WtHud2
             {
                 if (availableParamsBs.Contains(item))
                 {
-                    availableParamsBs.Remove(item);
+                    if (item.Name != separatorName)
+                    {
+                        availableParamsBs.Remove(item);
+                    }
+
                     activeParamsBs.Add(item);
                 }
             }


### PR DESCRIPTION
### Issue
Lets say we have a config:
![config_ok](https://github.com/wysiwyng/wthud2/assets/82443153/1123ca3e-3a4b-4d18-b5ae-9a2e2a1e9cec)
Then when we save it, and then try to load it again, only first `-SEPARATOR-` gets loaded.
![config_loaded](https://github.com/wysiwyng/wthud2/assets/82443153/631973d7-3488-46c3-9ab7-4259043951c5)
### Fix
When parameter name equals `-SEPARATOR-`, we don't remove it from available parameters list.